### PR TITLE
NLTK stopwords: another requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ Before running, you need to first install the required packages by typing follow
 $ pip3 install -r requirements.txt
 ```
 
+Also, you need to download the stopwords in the NLTK library:
+
+```
+import nltk
+nltk.download('stopwords')
+```
+
 Python 3.6 or above is strongly recommended; using older python versions might lead to package incompatibility issues.
 
 ## Reproducing the Results


### PR DESCRIPTION
I got this error in my first trial, this commit would solve this problem for others.

```
Traceback (most recent call last):
  File "src/train.py", line 66, in <module>
    main()
  File "src/train.py", line 55, in main
    trainer.category_vocabulary(top_pred_num=args.top_pred_num, category_vocab_size=args.category_vocab_size)
  File "/home/ec2-user/SageMaker/LOTClass-master/src/trainer.py", line 306, in category_vocabulary
    self.filter_keywords(category_vocab_size)
  File "/home/ec2-user/SageMaker/LOTClass-master/src/trainer.py", line 246, in filter_keywords
    stopwords_vocab = stopwords.words('english')
  File "/home/ec2-user/anaconda3/envs/JupyterSystemEnv/lib/python3.7/site-packages/nltk/corpus/util.py", line 120, in __getattr__
    self.__load()
  File "/home/ec2-user/anaconda3/envs/JupyterSystemEnv/lib/python3.7/site-packages/nltk/corpus/util.py", line 85, in __load
    raise e
  File "/home/ec2-user/anaconda3/envs/JupyterSystemEnv/lib/python3.7/site-packages/nltk/corpus/util.py", line 80, in __load
    root = nltk.data.find("{}/{}".format(self.subdir, self.__name))
  File "/home/ec2-user/anaconda3/envs/JupyterSystemEnv/lib/python3.7/site-packages/nltk/data.py", line 585, in find
    raise LookupError(resource_not_found)
LookupError: 
**********************************************************************
  Resource stopwords not found.
  Please use the NLTK Downloader to obtain the resource:

  >>> import nltk
  >>> nltk.download('stopwords')
  
  For more information see: https://www.nltk.org/data.html

  Attempted to load corpora/stopwords

  Searched in:
    - '/home/ec2-user/nltk_data'
    - '/home/ec2-user/anaconda3/envs/JupyterSystemEnv/nltk_data'
    - '/home/ec2-user/anaconda3/envs/JupyterSystemEnv/share/nltk_data'
    - '/home/ec2-user/anaconda3/envs/JupyterSystemEnv/lib/nltk_data'
    - '/usr/share/nltk_data'
    - '/usr/local/share/nltk_data'
    - '/usr/lib/nltk_data'
    - '/usr/local/lib/nltk_data'
**********************************************************************
```